### PR TITLE
Refactor FacebookEventDispatcher

### DIFF
--- a/dispatchers/facebook-event/src/main/java/com/trendyol/osiris/dispatcher/facebook/FacebookEvent.kt
+++ b/dispatchers/facebook-event/src/main/java/com/trendyol/osiris/dispatcher/facebook/FacebookEvent.kt
@@ -2,8 +2,15 @@ package com.trendyol.osiris.dispatcher.facebook
 
 import com.trendyol.osiris.EventData
 
-data class FacebookEvent(
-    val price: Double,
-    val currency: String,
-    val params: Map<String, String>,
-) : EventData
+sealed class FacebookEventContract(open val params: Map<String, String>) {
+
+    data class FacebookEvent(
+        override val params: Map<String, String>,
+    ) : EventData, FacebookEventContract(params)
+
+    data class FacebookPurchaseEvent(
+        override val params: Map<String, String>,
+        val price: Double,
+        val currency: String,
+    ) : EventData, FacebookEventContract(params)
+}

--- a/dispatchers/facebook/src/main/java/com/trendyol/osiris/dispatcher/facebook/FacebookDispatcher.kt
+++ b/dispatchers/facebook/src/main/java/com/trendyol/osiris/dispatcher/facebook/FacebookDispatcher.kt
@@ -1,11 +1,10 @@
 package com.trendyol.osiris.dispatcher.facebook
 
 import android.content.Context
-import com.facebook.appevents.AppEventsConstants
 import com.facebook.appevents.AppEventsLogger
-import com.trendyol.osiris.EventDispatcher
 import com.trendyol.osiris.Event
 import com.trendyol.osiris.EventData
+import com.trendyol.osiris.EventDispatcher
 import com.trendyol.osiris.util.bundleOf
 import java.math.BigDecimal
 import java.util.Currency
@@ -15,23 +14,22 @@ class FacebookDispatcher(context: Context) : EventDispatcher {
     private val appEventsLogger: AppEventsLogger = AppEventsLogger.newLogger(context)
 
     override fun logEvent(event: Event<EventData>) {
-        val facebookEvent = event.data as com.trendyol.osiris.dispatcher.facebook.FacebookEvent
 
-        if (event.name == AppEventsConstants.EVENT_NAME_PURCHASED) {
-            appEventsLogger.logPurchase(
-                BigDecimal.valueOf(facebookEvent.price),
-                Currency.getInstance(facebookEvent.currency),
-                bundleOf(facebookEvent.params),
-            )
-        } else {
-            appEventsLogger.logEvent(
-                event.name,
-                bundleOf(facebookEvent.params),
-            )
+        when (val facebookEvent = event.data as FacebookEventContract) {
+            is FacebookEventContract.FacebookEvent -> {
+                appEventsLogger.logEvent(event.name, bundleOf(facebookEvent.params))
+            }
+            is FacebookEventContract.FacebookPurchaseEvent -> {
+                appEventsLogger.logPurchase(
+                    BigDecimal.valueOf(facebookEvent.price),
+                    Currency.getInstance(facebookEvent.currency),
+                    bundleOf(facebookEvent.params)
+                )
+            }
         }
     }
 
     override fun isSatisfied(event: Event<EventData>): Boolean {
-        return event.data is com.trendyol.osiris.dispatcher.facebook.FacebookEvent
+        return event.data is FacebookEventContract
     }
 }

--- a/dispatchers/firebase-event/src/main/java/com/trendyol/osiris/dispatcher/firebase/FirebaseEvent.kt
+++ b/dispatchers/firebase-event/src/main/java/com/trendyol/osiris/dispatcher/firebase/FirebaseEvent.kt
@@ -3,5 +3,5 @@ package com.trendyol.osiris.dispatcher.firebase
 import com.trendyol.osiris.EventData
 
 data class FirebaseEvent(
-    val params: Map<String, String>,
+    val params: Map<String, Any>,
 ) : EventData


### PR DESCRIPTION
- To make purchase event and regular event sending explicit, related classes are created.
- Support all data types for firebase event values